### PR TITLE
Fix JSON flattening for malformed quotes

### DIFF
--- a/main.py
+++ b/main.py
@@ -616,9 +616,10 @@ def safe_json_loads(s: str):
     try:
         return json.loads(s)
     except Exception as ex:
-        # Пробуем заменить одинарные кавычки на двойные
         try:
-            fixed = s.replace("'", '"')
+            # Убираем последовательности тройных кавычек и одинарные кавычки
+            fixed = re.sub(r'"{2,}', '"', s)
+            fixed = fixed.replace("'", '"')
             return json.loads(fixed)
         except Exception:
             logging.debug(f"[safe_json_loads] Ошибка: {ex} | Исходная строка: {repr(s)}")


### PR DESCRIPTION
## Summary
- handle repeated quotes when parsing JSON

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_688283e00f948325ac70798ddd8e20b3