### PR TITLE
Ensure JSON columns include all fields

### DIFF
--- a/main.py
+++ b/main.py
@@ -647,8 +647,11 @@ def flatten_json_column_recursive(df, column, prefix=None, sheet=None, sep="; ")
                     item_prefix = f"{current_prefix} => [{idx}]"
                     fields.update(extract(x, item_prefix))
         else:
-            # Сюда могут попасть nan, пустые строки, и т.п.
-            if obj not in (None, "", float('nan')):
+            # Даже если значение пустое или None, колонка должна
+            # присутствовать для всех возможных ключей
+            if isinstance(obj, float) and pd.isna(obj):
+                fields[current_prefix] = None
+            else:
                 fields[current_prefix] = obj
         return fields
 


### PR DESCRIPTION
## Summary
- keep JSON columns even if values are blank

## Testing
- `python -m py_compile main.py`
- `python - <<'PY'
import pandas as pd
from main import flatten_json_column_recursive
json_strings=['{"teamNews":"","nftFlg":"N"}','{"teamNews":""}']
df=pd.DataFrame({'REWARD_ADD_DATA':json_strings})
flatten_json_column_recursive(df,'REWARD_ADD_DATA', prefix='ADD_DATA', sheet='REWARD')
print(df)
PY
`

------
https://chatgpt.com/codex/tasks/task_e_68828f0892448325b1a0aad774fa3a80