### PR TITLE
config: показывать ошибочные run_outputs и блокировать выбор

### DIFF
--- a/src/Tests/test_run_outputs.py
+++ b/src/Tests/test_run_outputs.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from src.config_loader import parse_run_outputs_config
 
 
@@ -77,3 +79,20 @@ def test_rating_and_season_tokens_alone() -> None:
     assert ro[3] is True
     assert ro[10] is True
     assert ro[11] is True
+
+
+def test_run_outputs_reports_invalid_token_with_position() -> None:
+    with pytest.raises(ValueError) as exc:
+        parse_run_outputs_config({"run_outputs": ["main_only", "bad_token"]})
+    msg = str(exc.value)
+    assert "run_outputs[1]" in msg
+    assert "bad_token" in msg
+    assert "Допустимые значения" in msg
+
+
+def test_run_outputs_reports_non_string_item_with_position() -> None:
+    with pytest.raises(ValueError) as exc:
+        parse_run_outputs_config({"run_outputs": ["main_only", 42]})
+    msg = str(exc.value)
+    assert "run_outputs[1]" in msg
+    assert "ожидается строка" in msg

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -43,12 +43,34 @@ def parse_run_outputs_config(cfg: Dict[str, Any]) -> Tuple[List[str], bool, bool
     tokens: Set[str] = set()
 
     if isinstance(ro_raw, list) and len(ro_raw) > 0:
-        for item in ro_raw:
+        invalid_items: List[str] = []
+        allowed_values = ", ".join(sorted(_RUN_OUTPUT_TOKENS))
+        for idx, item in enumerate(ro_raw):
             if not isinstance(item, str):
+                invalid_items.append(
+                    f"run_outputs[{idx}]={item!r}: ожидается строка."
+                )
                 continue
-            t = item.strip().lower().replace("-", "_")
+            raw_token = item.strip()
+            if not raw_token:
+                invalid_items.append(
+                    f"run_outputs[{idx}]={item!r}: пустое значение."
+                )
+                continue
+            t = raw_token.lower().replace("-", "_")
             if t in _RUN_OUTPUT_TOKENS:
                 tokens.add(t)
+                continue
+            invalid_items.append(
+                f"run_outputs[{idx}]={item!r}: неизвестный токен «{t}»."
+            )
+        if invalid_items:
+            raise ValueError(
+                "run_outputs содержит недопустимые элементы:\n- "
+                + "\n- ".join(invalid_items)
+                + "\nДопустимые значения: "
+                + allowed_values
+            )
         if not tokens:
             raise ValueError(
                 "run_outputs: укажите хотя бы одно из значений: "


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Что сделано

Усилена валидация `run_outputs` в `src/config_loader.py`:

- ошибочные элементы теперь явно показываются в сообщении об ошибке;
- для каждого элемента указывается точная позиция в списке (`run_outputs[i]`);
- для каждого невалидного пункта выводится причина:
  - не строка,
  - пустое значение,
  - неизвестный токен;
- при наличии ошибок конфигурация не принимается (нельзя «выбрать» и продолжить с невалидным пунктом);
- в конце сообщения дается список допустимых значений.

## Зачем

Чтобы в момент выбора/настройки «что создавать» пользователь сразу видел неверные пункты и место ошибки, а запуск не продолжался с некорректной конфигурацией.

## Тесты

Добавлены тесты в `src/Tests/test_run_outputs.py`:

- ошибка по неизвестному токену с позицией;
- ошибка по нестроковому элементу с позицией.

Локальная проверка выполнена мини-прогоном через `python3` (в окружении отсутствует `pytest`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1780-6fe9-7793-85ef-be9c3a07b74b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1780-6fe9-7793-85ef-be9c3a07b74b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

